### PR TITLE
Add Variable Polling Intervals Based on Charging and Wake State

### DIFF
--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -125,6 +125,12 @@ namespace esphome
                                 public ble_client::BLEClientNode
         {
         public:
+            std::string charging_state_;
+            uint32_t last_update_time_ = 0;
+            uint32_t last_wake_time_ = 0;
+            static constexpr uint32_t CHARGING_POLL_INTERVAL = 2000;
+            static constexpr uint32_t NON_CHARGING_POLL_INTERVAL = 60000;
+            static constexpr uint32_t WAKE_POLLING_PERIOD = 300000;
             TeslaBLEVehicle();
             void setup() override;
             void loop() override;
@@ -241,6 +247,7 @@ namespace esphome
 
             void setChargingState (std::string charging_state)
             {
+                charging_state_ = charging_state;
                 ChargingStateSensor->publish_state (charging_state);
             }
 


### PR DESCRIPTION
### Description
This PR introduces variable polling intervals to optimize vehicle sleep behavior while maintaining responsiveness. The changes implement the following:

1. **Charging-Based Polling**:
   - Polls `CarServer` commands (e.g., `GET_CHARGE_STATE`, `GET_DRIVE_STATE`) every 2 seconds when the vehicle is charging.
   - Polls every 60 seconds when not charging to allow the vehicle to sleep.

2. **Post-Wake Polling**:
   - For 5 minutes after the vehicle wakes up (detected via `VCSEC_VehicleStatus`), polls `CarServer` commands every 2 seconds, regardless of charging state.
   - After 5 minutes, reverts to 60 seconds if not charging, or continues at 2 seconds if charging.

3. **Independent VCSEC Polling**:
   - Ensures `enqueueVCSECInformationRequest` is called every x (however set from the user) seconds, unaffected by charging or wake state, as it does not interrupt vehicle sleep.

