### PR TITLE
Keep Vehicle state after disconnect

### DIFF
--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -1697,9 +1697,9 @@ namespace esphome
         this->node_state = espbt::ClientState::IDLE;
 
         // set binary sensors to unknown
-        this->setSensors(false);
-        this->setInfotainmentSensors (false);
-        this->setChargeFlapHasState(false);
+        // this->setSensors(false);
+        // this->setInfotainmentSensors (false);
+        // this->setChargeFlapHasState(false);
 
         // TODO: charging switch off
         this->status_set_warning("BLE connection closed");


### PR DESCRIPTION
Update tesla_ble_vehicle.cpp

Don't invalidate sensors when unavailable to mitigate the consequences of connection less.

The current dev-branch sets all entities to unavailable once the connection breaks. I get the reasoning behind it, but in my experience BLE is not a reliable connection. After a few days of testing, I find that the connection fails several times a day even if the car isn't moving at all, with a reconnection happening within a few seconds. This happens for different reasons, either because of rf interference, or simply because too many devices try to connect to the car, and it will only accept 3 simultaneous connections.

When the entities turn to "unknown", this will break all logic in Home Assistant. I believe it's better to keep the last state through a short disconnect. If a car is really gone, invalicating entities can be done from the Home Assistant side quite easily, like automatically "pressing" the restart button when the car isn't connected for 60 seconds.

If the developer feels that data should be invalidated by the ESP32, this should be a configurable behaviour, or at least it should only happen when the car is not connected for at least a minute.