### PR TITLE
Cleaned up tesla-ble.example.yml

### DIFF
--- a/tesla-ble.example.yml
+++ b/tesla-ble.example.yml
@@ -1,19 +1,19 @@
 substitutions:
   # all substitutions for this project
-  espidf_version: 5.3.0
-  platformio_version: 6.8.1
   friendly_name: Tesla BLE
   device_name: tesla-ble
   device_description: Tesla BLE
-  board: esp32dev
-  variant: esp32
-  flash_size: 4MB
   ble_mac_address: !secret ble_mac_address
   tesla_vin: !secret tesla_vin
   charging_amps_max: "32"
 
 esp32:
-  board: esp32dev  # set as needed for your board
+  # generic ESP32: board esp32dev, variant esp32, flash: 4MB
+  # M5stack AtomS3: board esp32-s3-devkitc-1, variant esp32s3, flash: 8MB
+  #
+  board: esp32dev  # set as needed for your board, see above
+  variant: esp32   # set as needed for your board, see above
+  flash_size: 4MB
   framework:
     type: esp-idf
     version: 5.3.2
@@ -37,7 +37,7 @@ packages:
   # listener: github://PedroKTFC/esphome-tesla-ble/packages/listener.yml # Uncomment this to scan find your VIN BLE MAC address
 
 esphome:
-  name: ${name}
+  name: ${device_name}
   name_add_mac_suffix: false
   friendly_name: ${friendly_name}
   libraries:

--- a/tesla-ble.example.yml
+++ b/tesla-ble.example.yml
@@ -1,39 +1,27 @@
 substitutions:
   # all substitutions for this project
-  friendly_name: Tesla BLE
-  device_name: tesla-ble
+  friendly_name: Tesla BLE F549C4
+  device_name: tesla-ble-f549c4
   device_description: Tesla BLE
   ble_mac_address: !secret ble_mac_address
   tesla_vin: !secret tesla_vin
-  charging_amps_max: "32"
-
-esp32:
-  # generic ESP32: board esp32dev, variant esp32, flash: 4MB
-  # M5stack AtomS3: board esp32-s3-devkitc-1, variant esp32s3, flash: 8MB
-  #
-  board: esp32dev  # set as needed for your board, see above
-  variant: esp32   # set as needed for your board, see above
-  flash_size: 4MB
-  framework:
-    type: esp-idf
-    version: 5.3.2
+  charging_amps_max: "16"
 
 api:
   encryption:
-    key: xxxxxxxxxxxxx=
+    key: !secret api_encryption_key
 
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
 external_components:
-  source: github://PedroKTFC/esphome-tesla-ble
+  source: github://PedroKTFC/esphome-tesla-ble@dev
+
 
 packages:
-  base:  github://PedroKTFC/esphome-tesla-ble/packages/base.yml
-  common: github://PedroKTFC/esphome-tesla-ble/packages/common.yml
-  project: github://PedroKTFC/esphome-tesla-ble/packages/project.yml
-  client: github://PedroKTFC/esphome-tesla-ble/packages/client.yml
+  base:  github://top-gun/esphome-tesla-ble-test/packages/base.yml@dev
+  client: github://PedroKTFC/esphome-tesla-ble/packages/client.yml@dev
   # listener: github://PedroKTFC/esphome-tesla-ble/packages/listener.yml # Uncomment this to scan find your VIN BLE MAC address
 
 esphome:
@@ -41,7 +29,15 @@ esphome:
   name_add_mac_suffix: false
   friendly_name: ${friendly_name}
   libraries:
-    - https://github.com/PedroKTFC/tesla-ble.git
+    - https://github.com/PedroKTFC/tesla-ble.git#dev 
+    
+esp32:
+  board: esp32dev
+  variant: esp32
+  flash_size: 4MB
+  framework:
+    type: esp-idf
+
 
 tesla_ble_vehicle:
   odometer:
@@ -55,7 +51,11 @@ tesla_ble_vehicle:
     filters:
       - multiply: 1.60934 # Convert miles to kms
   update_interval: 2s # Base polling interval, used for VCSEC sensors
-  post_wake_poll_time: 300 # How long to poll for data after car awakes (s)
+  post_wake_poll_time: 180 # How long to poll for data after car awakes (s)
   poll_data_period: 60 # Normal period when polling for data when not asleep (s)
   poll_charging_period: 2 # Period to poll for data when charging (s)
   poll_asleep_period: 60 # Period to poll for data when asleep (s)
+  ble_disconnected_min_time: 120 # Minimum time BLE must be disconnected before sensors are Unknwon (s)
+
+esp32_ble_tracker:
+  max_connections: 1


### PR DESCRIPTION
substitutions:
Removed unused substitutions

esü32_
Added instructions for the board configuration of ESP32 (generic) and ESP32-S3 (also applies to AtomS3)

esphome: 
corrected variable for ESP-name - name was pointing to itself.