### PR TITLE
Fix external_components.dashboard.yml

### DIFF
--- a/packages/external_components.dashboard.yml
+++ b/packages/external_components.dashboard.yml
@@ -1,2 +1,2 @@
 - components: [tesla_ble_vehicle, tesla_ble_listener]
-  source: github://PedroKTFC/esphome-tesla-ble/components
+  source: github://PedroKTFC/esphome-tesla-ble


### PR DESCRIPTION
`github://PedroKTFC/esphome-tesla-ble/components` works, but as soon as you specify a branch like `github://PedroKTFC/esphome-tesla-ble/components@dev` esphome silently still uses the previously downloaded `github://PedroKTFC/esphome-tesla-ble/components` and compilation errors occur.

using
`github://PedroKTFC/esphome-tesla-ble`
and 
`github://PedroKTFC/esphome-tesla-ble@dev`
directly solves the issue, so changing it here so others do not waste time chasing ghosts