### PR TITLE
Update tesla-ble.example.yml

### DIFF
--- a/tesla-ble.example.yml
+++ b/tesla-ble.example.yml
@@ -36,7 +36,7 @@ esphome:
   name_add_mac_suffix: false
   friendly_name: ${friendly_name}
   libraries:
-    - https://github.com/PedroKTFC/tesla-ble.git
+    - TeslaBLE=https://github.com/PedroKTFC/tesla-ble.git
 
 tesla_ble_vehicle:
   odometer: # miles by default, edit the entity in home assistant if you need km


### PR DESCRIPTION
ESPHome 2025.8.0 has a breaking change: Libraries need to be given a name at load time, anonymous libraries are no longer allowed.

https://github.com/esphome/esphome/pull/9378

This is the fix I got from the ESPHome developers on Discord. Simply adding "TeslaBLE=" in the library statement fixes it.
