### PR TITLE
Charging amps under 5A

### DIFF
--- a/packages/client.yml
+++ b/packages/client.yml
@@ -329,7 +329,12 @@ number:
     set_action:
       - lambda: |-
           int var_x = static_cast<int>(x);
-          id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(SET_CHARGING_AMPS, var_x);
+          if (x < 5) {
+              id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(SET_CHARGING_AMPS, var_x);
+              id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(SET_CHARGING_AMPS, var_x);
+          } else {
+              id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(SET_CHARGING_AMPS, var_x);
+          }
     lambda: |-
       if (id(max_amps).has_state())
       {


### PR DESCRIPTION
Based on [info](https://github.com/yoziru/esphome-tesla-ble/issues/77#issuecomment-2551258411), this is tested and works:
- values under 5 need to be sent twice over BLE for the car to accept them
- they are not displayed in the Charging settings page of the car (shown as 5A)
- setting to under 5A during charge really decreases charging current, this is reflected on the status area of the screen, by showing the lowered current and the increased time to charge (also _Minutes to limit_, _Charge power_, _Current limit_ reflect the change accordingly). The actual current can also be seen in the phone app.
- restarting the charge procedure (eg by replugging the connector) will reset the minimum to 5A. Thus, it's useless to set the value when the car is not actually charging, but can be set after the charge has started

This is useful for cases when some charge is still desired, but very low power is available.