### PR TITLE
Remove double "wifi:" codeblock from "tesla-ble.example.yml"

### DIFF
--- a/tesla-ble.example.yml
+++ b/tesla-ble.example.yml
@@ -16,11 +16,6 @@ api:
   encryption:
     key: xxxxxxxxxxxxx= # use "key: !secret your_secret_key_name" for greater security
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-#  use_address: 172.16.0.109 # Uncomment this and put your board's IP address if you cannot connect to your board over WiFi
-
 external_components:
   source: github://PedroKTFC/esphome-tesla-ble
 


### PR DESCRIPTION
The "wifi:" codeblock can be removed because it is also specified in “packages/base.yml”. Rationale: Keep most not project specific configuration out of sight of unexperienced users and simplify code.