### PR TITLE
Update Read.me regarding recommended and alternative path for flashing Tesla BLE code

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The following is the original method. I have never tried this and I do not maint
 **Recommended path**
 
 For an example ESPHome dashboard, see [`tesla-ble-example.yml`](./tesla-ble.example.yml). Please always start from this. I strongly recommend building this using the ESPHome Device Builder add-on in Home Assistant as this makes building and re-building (eg for updates) much easier.
-I you have limited experience with flashing ESP32 devices and want to get more familiar, check Lazy Tech Geek's video https://www.youtube.com/watch?v=XMpNJgozF-c
+If you have limited experience with flashing ESP32 devices and want to get more familiar, check Lazy Tech Geek's video https://www.youtube.com/watch?v=XMpNJgozF-c
 
 **Alternative**
 
@@ -206,6 +206,7 @@ The following are instructions if you use `make`. I have never used these so can
 1. [optional] Rename your key to "ESPHome BLE" to make it easier to identify
 
     <img src="./docs/vehicle-locks.png" width="500">
+
 
 
 


### PR DESCRIPTION
Today I saw a very good youtube video explaining how to work with ESPHome. This could support the project especially for users who want to use the repo but are not yet familiar with how to flash ESP32 devices in ESPHome.
I made a proposal to refer to that video and to split most of the steps into a "Recommended path" (using ESPHome) and an "Alternative" (the initial Yoziru way).

Please take a look. If it doesn't suit you, just throw it away. No hard feelings. 