### PR TITLE
Add IDs to remaining entities

### DIFF
--- a/packages/client.yml
+++ b/packages/client.yml
@@ -135,7 +135,7 @@ button:
     disabled_by_default: true
 
   - platform: template
-      id: btn_regen_key
+    id: btn_regen_key
     name: Regenerate key
     icon: mdi:key-change
     on_press:


### PR DESCRIPTION
Adding IDs to all entities allows for adding localization of them to any language.

Eg in the example yaml, to customize these:

```yaml
tesla_ble_vehicle:
  is_asleep:
    name: "Alvó állapotban"
  is_user_present:
    name: "Személy utastérben"

button:
  - id: !extend ble_pair
    name: BLE kulcspárosítás

number:
  - id: !extend charging_amps
    name: "Töltési áram"

cover:
  - id: !extend cov_boot
    name: "Csomagtartó"
```

To [follow](https://github.com/PedroKTFC/esphome-tesla-ble/discussions/133#discussioncomment-14270161) up, currently only entities under `tesla_ble_vehicle` can be localized without this.

Any future template entity that will be added will need to have an ID set in order to be translatable via package.