### PR TITLE
Add the use of M5stack Nano C6 to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,36 @@ The following is the original method. I have never tried this and I do not maint
 **Recommended path**
 
 For an example ESPHome dashboard, see [`tesla-ble-example.yml`](./tesla-ble.example.yml). Please always start from this. I strongly recommend building this using the ESPHome Device Builder add-on in Home Assistant as this makes building and re-building (eg for updates) much easier.
+
+- ESP32: The [`tesla-ble-example.yml`](./tesla-ble.example.yml) is setup to be used with a standard ESP32 device.
+- M5Stack Nano C6: If you want to use a [M5Stack Nano C6](https://docs.m5stack.com/en/core/M5NanoC6), then replace the lines:
+  ```
+  board: "esp32dev"
+  variant: "ESP32"
+  ```
+  with
+  ```
+  board: esp32-c6-devkitm-1
+  variant: esp32c6
+  ```
+  Optionally, by adding the code below a RBG LED can be installend which can can be used in your automations (e.g. to visually represent the loading status).
+  ```
+  light:
+    - platform: esp32_rmt_led_strip
+      rgb_order: GRB
+      pin: GPIO20
+      num_leds: 4
+      chipset: ws2812
+      name: "RGB LED"
+      entity_category: diagnostic
+      power_supply: rgbpwr
+  power_supply:
+    - id: 'rgbpwr'
+      enable_on_boot: true
+      pin: GPIO19
+      enable_time: 10ms
+      keep_on_time: 10ms
+  ```  
 If you have limited experience with flashing ESP32 devices and want to get more familiar, check Lazy Tech Geek's video https://www.youtube.com/watch?v=XMpNJgozF-c
 
 **Alternative**
@@ -231,4 +261,6 @@ The following are instructions if you use `make`. I have never used these so can
 [releases]: https://github.com/Blackymas/PedroKTFC/esphome-tesla-ble
 [last-commit-shield]: https://img.shields.io/github/last-commit/PedroKTFC/esphome-tesla-ble
 [platform-shield]: https://img.shields.io/badge/platform-Home%20Assistant%20&%20ESPHome-blue
+
+
 

--- a/boards/m5stack-nanoc6.yml
+++ b/boards/m5stack-nanoc6.yml
@@ -1,3 +1,12 @@
+##--- NOTE -------------------------------------------------------------##
+# This file is not needed and not used in this repo configuration.       #
+# It was taken over by forking the original yoziru repo.                 #
+# In case a M5stack Nano C6 is used, nescessary config can be made in    #
+#   the root yaml file (tesla-ble.example.yml) as described in the       #
+#   read.me.                                                             #
+##----------------------------------------------------------------------##
+
+
 substitutions:
   board: esp32-c6-devkitm-1
   variant: esp32c6

--- a/tesla-ble.example.yml
+++ b/tesla-ble.example.yml
@@ -5,9 +5,9 @@ substitutions:
   ble_mac_address: !secret ble_mac_address
   tesla_vin: !secret tesla_vin
   charging_amps_max: "32"
-# The following shows the default board and variant settings. Uncomment and change them if they are not appropriate for your board:
-  #board: "esp32dev"
-  #variant: "ESP32"
+# The following shows the default board and variant settings. Change them if they are not appropriate for your board (see read.me documentation for support):
+  board: "esp32dev"
+  variant: "ESP32"
 
 api:
   encryption:


### PR DESCRIPTION
Initially I tried to setup a "library" with different mcu's in the "board" folder. However, this was not straightforward since the "board" and "variant" variables are not only used in the "root" yml file. To keep things easy and bug-free, I do not want to make to many changes to this well working solution.
Since my estimate is that the number of ESP32 variants will be limited, I propose to just specify in the documentation how to change the "root" yml file in case a user want to deviate from the default ESP32 mcu. 
In this PR:
- Read.me has been updated
- tesla-ble.example.yml has been slightly adapted to set ESP32 as the default mcu
- a comment has been put in the "boards/m5stack-nanoc6.yml" file stating that this file is not necessary in the config.