### PR TITLE
Add support for multiple Tesla vehicles on a single ESP32

### DIFF
--- a/components/tesla_ble_vehicle/__init__.py
+++ b/components/tesla_ble_vehicle/__init__.py
@@ -154,6 +154,8 @@ for key, spec in SENSORS.items():
     builder = SENSOR_TYPES_INFO[spec.type]["schema"]
     schema_dict[cv.Optional(key)] = (builder(**spec.schema_options))
 
+MULTI_CONF = True
+
 CONFIG_SCHEMA = (
     cv.Schema(schema_dict)
     .extend(cv.polling_component_schema("1min"))
@@ -163,6 +165,10 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await ble_client.register_ble_node(var, config)
+
+    component_id = str(config[CONF_ID])
+    nvs_namespace = "storage" if component_id == "tesla_ble_vehicle_id" else component_id[:15]
+    cg.add(var.set_nvs_namespace(nvs_namespace))
 
     cg.add(var.set_vin(config[CONF_VIN]))
 

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -60,7 +60,7 @@ namespace esphome
 
     void TeslaBLEVehicle::openNVSHandle()
     {
-      esp_err_t err = nvs_open("storage", NVS_READWRITE, &this->storage_handle_);
+      esp_err_t err = nvs_open(this->nvs_namespace_, NVS_READWRITE, &this->storage_handle_);
       if (err != ESP_OK)
       {
         ESP_LOGE(TAG, "Failed to open NVS handle: %s", esp_err_to_name(err));
@@ -1193,6 +1193,12 @@ if (ble_disconnected_ != BleConnected) // While disconnected update duration of 
       return 0;
     }
 
+    void TeslaBLEVehicle::set_nvs_namespace(const char *ns)
+    {
+      snprintf(this->nvs_namespace_, sizeof(this->nvs_namespace_), "%s", ns);
+      ESP_LOGI(TAG, "NVS namespace: %s", this->nvs_namespace_);
+    }
+
     void TeslaBLEVehicle::set_vin(const char *vin)
     {
       tesla_ble_client_->setVIN(vin);
@@ -1233,7 +1239,7 @@ if (ble_disconnected_ != BleConnected) // While disconnected update duration of 
         ESP_LOGE(TAG, "Failed to initialize flash: %s", esp_err_to_name(err));
       }
 
-      err = nvs_open("storage", NVS_READWRITE, &this->storage_handle_);
+      err = nvs_open(this->nvs_namespace_, NVS_READWRITE, &this->storage_handle_);
       if (err != ESP_OK)
       {
         ESP_LOGE(TAG, "Failed to open NVS handle: %s", esp_err_to_name(err));

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -60,7 +60,7 @@ namespace esphome
 
     void TeslaBLEVehicle::openNVSHandle()
     {
-      esp_err_t err = nvs_open(this->nvs_namespace_, NVS_READWRITE, &this->storage_handle_);
+      esp_err_t err = nvs_open(this->nvs_namespace_.c_str(), NVS_READWRITE, &this->storage_handle_);
       if (err != ESP_OK)
       {
         ESP_LOGE(TAG, "Failed to open NVS handle: %s", esp_err_to_name(err));
@@ -1193,10 +1193,10 @@ if (ble_disconnected_ != BleConnected) // While disconnected update duration of 
       return 0;
     }
 
-    void TeslaBLEVehicle::set_nvs_namespace(const char *ns)
+    void TeslaBLEVehicle::set_nvs_namespace(const std::string &ns)
     {
-      snprintf(this->nvs_namespace_, sizeof(this->nvs_namespace_), "%s", ns);
-      ESP_LOGI(TAG, "NVS namespace: %s", this->nvs_namespace_);
+      this->nvs_namespace_ = ns.substr(0, 15);
+      ESP_LOGI(TAG, "NVS namespace: %s", this->nvs_namespace_.c_str());
     }
 
     void TeslaBLEVehicle::set_vin(const char *vin)
@@ -1239,7 +1239,7 @@ if (ble_disconnected_ != BleConnected) // While disconnected update duration of 
         ESP_LOGE(TAG, "Failed to initialize flash: %s", esp_err_to_name(err));
       }
 
-      err = nvs_open(this->nvs_namespace_, NVS_READWRITE, &this->storage_handle_);
+      err = nvs_open(this->nvs_namespace_.c_str(), NVS_READWRITE, &this->storage_handle_);
       if (err != ESP_OK)
       {
         ESP_LOGE(TAG, "Failed to open NVS handle: %s", esp_err_to_name(err));

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -290,6 +290,7 @@ namespace esphome
             void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                      esp_ble_gattc_cb_param_t *param) override;
             void dump_config() override;
+	    void set_nvs_namespace(const char *ns);
             void set_vin(const char *vin);
             void load_polling_parameters (const int post_wake_poll_time, const int poll_data_period,
                                           const int poll_asleep_period, const int poll_charging_period,
@@ -439,6 +440,7 @@ namespace esphome
 
             TeslaBLE::Client *tesla_ble_client_;
             uint32_t storage_handle_;
+	    char nvs_namespace_[16];
             uint16_t handle_;
             uint16_t read_handle_{0};
             uint16_t write_handle_{0};

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -290,7 +290,7 @@ namespace esphome
             void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                      esp_ble_gattc_cb_param_t *param) override;
             void dump_config() override;
-	    void set_nvs_namespace(const char *ns);
+            void set_nvs_namespace(const std::string &ns);
             void set_vin(const char *vin);
             void load_polling_parameters (const int post_wake_poll_time, const int poll_data_period,
                                           const int poll_asleep_period, const int poll_charging_period,
@@ -440,7 +440,7 @@ namespace esphome
 
             TeslaBLE::Client *tesla_ble_client_;
             uint32_t storage_handle_;
-	    char nvs_namespace_[16];
+            std::string nvs_namespace_;
             uint16_t handle_;
             uint16_t read_handle_{0};
             uint16_t write_handle_{0};

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -7,6 +7,15 @@ ble_client:
   - mac_address: $ble_mac_address
     id: ble_tesla_id
 
+binary_sensor:
+  - platform: ble_presence
+    id: esphome_tesla_ble_ble_status
+    mac_address: $ble_mac_address
+    device_class: connectivity
+    name: "BLE Status"
+    entity_category: diagnostic
+    timeout: $ble_presence_timeout
+
 tesla_ble_vehicle:
   ble_client_id: ble_tesla_id
   id: tesla_ble_vehicle_id

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -2,327 +2,329 @@ substitutions:
   ble_mac_address: !secret ble_mac_address
   tesla_vin: !secret tesla_vin
   charging_amps_max: "32"
+  car_prefix: ""
+  car_name: ""
 
 ble_client:
   - mac_address: $ble_mac_address
-    id: ble_tesla_id
+    id: ${car_prefix}ble_tesla_id
 
 binary_sensor:
   - platform: ble_presence
-    id: esphome_tesla_ble_ble_status
+    id: ${car_prefix}esphome_tesla_ble_ble_status
     mac_address: $ble_mac_address
     device_class: connectivity
-    name: "BLE Status"
+    name: "${car_name}BLE Status"
     entity_category: diagnostic
     timeout: $ble_presence_timeout
 
 tesla_ble_vehicle:
-  ble_client_id: ble_tesla_id
-  id: tesla_ble_vehicle_id
-  vin: $tesla_vin
-  update_interval: 10s # default
-  post_wake_poll_time: 300 # How long to poll for data after car awakes (s)
-  poll_data_period: 60 # Normal period when polling for data when not asleep (s)
-  poll_asleep_period: 60 # Period to poll for data when asleep (s)
-  poll_charging_period: 10 # Period to poll for data when charging (s)
-  ble_disconnected_min_time: 300 # Minimum time BLE must be disconnected before sensors are Unknwon (s)
-  fast_poll_if_unlocked: 0 # if != 0, fast polls are enabled when unlocked
-  wake_on_boot: 0 # != 0 wakes car on device boot
+  - ble_client_id: ${car_prefix}ble_tesla_id
+    id: ${car_prefix}tesla_ble_vehicle_id
+    vin: $tesla_vin
+    update_interval: 10s # default
+    post_wake_poll_time: 300 # How long to poll for data after car awakes (s)
+    poll_data_period: 60 # Normal period when polling for data when not asleep (s)
+    poll_asleep_period: 60 # Period to poll for data when asleep (s)
+    poll_charging_period: 10 # Period to poll for data when charging (s)
+    ble_disconnected_min_time: 300 # Minimum time BLE must be disconnected before sensors are Unknwon (s)
+    fast_poll_if_unlocked: 0 # if != 0, fast polls are enabled when unlocked
+    wake_on_boot: 0 # != 0 wakes car on device boot
 
-  is_asleep:
-    id: "is_asleep"
-    name: "Asleep"
-  is_user_present:
-    id: "is_user_present"
-    name: "User presence"
-  is_unlocked:
-    id: "is_unlocked"
-    name: "Doors"
-  is_charge_flap_open:
-    id: "is_charge_flap_open"
-    name: "Charge flap"
-  is_boot_open:
-    id: "is_boot_open"
-    name: "Boot"
-  is_frunk_open:
-    id: "is_frunk_open"
-    name: "Frunk"
-  shift_state:
-    id: "shift_state"
-    name: "Shift state"
-  defrost_state:
-    id: "defrost_state"
-    name: "Defrost state"
-  charge_state:
-    id: "charge_state"
-    name: "Charge level"
-  odometer:
-    id: "odometer"
-    name: "Odometer"
-    filters:
-      - multiply: 0.01 # Odometer is in hundredths of a mile (can use this to convert to km)
-  charge_current:
-    id: "charge_current"
-    name: "Charge current"
-  charge_voltage:
-    id: "charge_voltage"
-    name: "Charge voltage"  
-  charge_power:
-    id: "charge_power"
-    name: "Charge power"
-  charge_energy_added:
-    id: "charge_energy_added"
-    name: "Charge energy added"
-  charge_distance_added:
-    id: "charge_distance_added"
-    name: "Charge distance added"
-  max_soc:
-    id: "max_soc"
-    name: "Charge limit"
-  max_amps:
-    id: "max_amps"
-    name: "Current limit"
-  mins_to_limit:
-    id: "mins_to_limit"
-    name: "Minutes to limit"
-  battery_range:
-    id: "battery_range"
-    name: "Range"
-  charging_state:
-    id: "charging_state"
-    name: "Charging state"
-  charge_port_latch_state:
-    id: "charge_port_latch_state"
-    name: "Charge port latch state"
-    disabled_by_default: true
-  last_update:
-    id: "last_update"
-    name: "Last update"
-  is_climate_on:
-    id: "is_climate_on"
-    name: "Climate"
-  internal_temp:
-    id: "internal_temp"
-    name: "Interior"
-  external_temp:
-    id: "external_temp"
-    name: "Exterior"
-  windows_state:
-    id: "windows_state"
-    name: "Windows"
-  tpms_pressure_fl:
-    id: "tpms_pressure_fl"
-    name: "Tyre pressure front left"
-    disabled_by_default: true
-  tpms_pressure_fr:
-    id: "tpms_pressure_fr"
-    name: "Tyre pressure front right"
-    disabled_by_default: true
-  tpms_pressure_rl:
-    id: "tpms_pressure_rl"
-    name: "Tyre pressure rear left"
-    disabled_by_default: true
-  tpms_pressure_rr:
-    id: "tpms_pressure_rr"
-    name: "Tyre pressure rear right"
-    disabled_by_default: true
-  ble_disconnected_time:
-    id: "ble_disconnected_time"
-    name: "BLE disconnected time"
-    disabled_by_default: true
-    entity_category: diagnostic
-  charger_phases:
-    id: "charger_phases"
-    name: "Charger phases"
-    disabled_by_default: true
-    filters:
-      - lambda: |-
-          if (x == 2)
-            return 3;
-          return x;
-  charge_rate:
-    id: "charge_rate"
-    name: "Charge rate"
-    disabled_by_default: true
-  driver_temp:
-    id: "driver_temp"
-    name: "Climate temperature" # although it's the driver side temperature setting, use it for the overall climate setting
-    disabled_by_default: true
+    is_asleep:
+      id: "${car_prefix}is_asleep"
+      name: "${car_name}Asleep"
+    is_user_present:
+      id: "${car_prefix}is_user_present"
+      name: "${car_name}User presence"
+    is_unlocked:
+      id: "${car_prefix}is_unlocked"
+      name: "${car_name}Doors"
+    is_charge_flap_open:
+      id: "${car_prefix}is_charge_flap_open"
+      name: "${car_name}Charge flap"
+    is_boot_open:
+      id: "${car_prefix}is_boot_open"
+      name: "${car_name}Boot"
+    is_frunk_open:
+      id: "${car_prefix}is_frunk_open"
+      name: "${car_name}Frunk"
+    shift_state:
+      id: "${car_prefix}shift_state"
+      name: "${car_name}Shift state"
+    defrost_state:
+      id: "${car_prefix}defrost_state"
+      name: "${car_name}Defrost state"
+    charge_state:
+      id: "${car_prefix}charge_state"
+      name: "${car_name}Charge level"
+    odometer:
+      id: "${car_prefix}odometer"
+      name: "${car_name}Odometer"
+      filters:
+        - multiply: 0.01 # Odometer is in hundredths of a mile (can use this to convert to km)
+    charge_current:
+      id: "${car_prefix}charge_current"
+      name: "${car_name}Charge current"
+    charge_voltage:
+      id: "${car_prefix}charge_voltage"
+      name: "${car_name}Charge voltage"  
+    charge_power:
+      id: "${car_prefix}charge_power"
+      name: "${car_name}Charge power"
+    charge_energy_added:
+      id: "${car_prefix}charge_energy_added"
+      name: "${car_name}Charge energy added"
+    charge_distance_added:
+      id: "${car_prefix}charge_distance_added"
+      name: "${car_name}Charge distance added"
+    max_soc:
+      id: "${car_prefix}max_soc"
+      name: "${car_name}Charge limit"
+    max_amps:
+      id: "${car_prefix}max_amps"
+      name: "${car_name}Current limit"
+    mins_to_limit:
+      id: "${car_prefix}mins_to_limit"
+      name: "${car_name}Minutes to limit"
+    battery_range:
+      id: "${car_prefix}battery_range"
+      name: "${car_name}Range"
+    charging_state:
+      id: "${car_prefix}charging_state"
+      name: "${car_name}Charging state"
+    charge_port_latch_state:
+      id: "${car_prefix}charge_port_latch_state"
+      name: "${car_name}Charge port latch state"
+      disabled_by_default: true
+    last_update:
+      id: "${car_prefix}last_update"
+      name: "${car_name}Last update"
+    is_climate_on:
+      id: "${car_prefix}is_climate_on"
+      name: "${car_name}Climate"
+    internal_temp:
+      id: "${car_prefix}internal_temp"
+      name: "${car_name}Interior"
+    external_temp:
+      id: "${car_prefix}external_temp"
+      name: "${car_name}Exterior"
+    windows_state:
+      id: "${car_prefix}windows_state"
+      name: "${car_name}Windows"
+    tpms_pressure_fl:
+      id: "${car_prefix}tpms_pressure_fl"
+      name: "${car_name}Tyre pressure front left"
+      disabled_by_default: true
+    tpms_pressure_fr:
+      id: "${car_prefix}tpms_pressure_fr"
+      name: "${car_name}Tyre pressure front right"
+      disabled_by_default: true
+    tpms_pressure_rl:
+      id: "${car_prefix}tpms_pressure_rl"
+      name: "${car_name}Tyre pressure rear left"
+      disabled_by_default: true
+    tpms_pressure_rr:
+      id: "${car_prefix}tpms_pressure_rr"
+      name: "${car_name}Tyre pressure rear right"
+      disabled_by_default: true
+    ble_disconnected_time:
+      id: "${car_prefix}ble_disconnected_time"
+      name: "${car_name}BLE disconnected time"
+      disabled_by_default: true
+      entity_category: diagnostic
+    charger_phases:
+      id: "${car_prefix}charger_phases"
+      name: "${car_name}Charger phases"
+      disabled_by_default: true
+      filters:
+        - lambda: |-
+            if (x == 2)
+              return 3;
+            return x;
+    charge_rate:
+      id: "${car_prefix}charge_rate"
+      name: "${car_name}Charge rate"
+      disabled_by_default: true
+    driver_temp:
+      id: "${car_prefix}driver_temp"
+      name: "${car_name}Climate temperature" # although it's the driver side temperature setting, use it for the overall climate setting
+      disabled_by_default: true
 
 button:
   - platform: template
-    id: ble_pair
-    name: Pair BLE key
+    id: ${car_prefix}ble_pair
+    name: "${car_name}Pair BLE key"
     icon: mdi:key-wireless
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->startPair();
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->startPair();
     entity_category: diagnostic
 
   - platform: template
-    id: btn_wake_up
-    name: Wake up
+    id: ${car_prefix}btn_wake_up
+    name: "${car_name}Wake up"
     icon: mdi:sleep-off
     on_press:
-    - lambda: id(tesla_ble_vehicle_id)->wakeVehicle();
+    - lambda: id(${car_prefix}tesla_ble_vehicle_id)->wakeVehicle();
 
   - platform: template
-    id: btn_flash_light
-    name: Flash light
+    id: ${car_prefix}btn_flash_light
+    name: "${car_name}Flash light"
     icon: mdi:car-light-high
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::FLASH_LIGHT, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::FLASH_LIGHT, 0);
 
   - platform: template
-    id: btn_sound_horn
-    name: Sound horn
+    id: ${car_prefix}btn_sound_horn
+    name: "${car_name}Sound horn"
     icon: mdi:bugle
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::SOUND_HORN, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::SOUND_HORN, 0);
 
   - platform: template
-    id: btn_unlock_charge_port
-    name: Unlock charge port
+    id: ${car_prefix}btn_unlock_charge_port
+    name: "${car_name}Unlock charge port"
     icon: mdi:ev-plug-ccs2
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_chargePort_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_chargePort_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
 
   - platform: template
-    id: btn_unlatch_driver_door
-    name: Unlatch driver door
+    id: ${car_prefix}btn_unlatch_driver_door
+    name: "${car_name}Unlatch driver door"
     icon: mdi:car-door
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_frontDriverDoor_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_frontDriverDoor_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
     disabled_by_default: true
 
   - platform: template
-    id: btn_media_play
-    name: Media play⁄pause # Normal / is not allowed here so use alternative fraction symbol
+    id: ${car_prefix}btn_media_play
+    name: "${car_name}Media play⁄pause" # Normal / is not allowed here so use alternative fraction symbol
     icon: mdi:play-pause
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::MEDIA_PLAY, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::MEDIA_PLAY, 0);
     disabled_by_default: true
 
   - platform: template
-    id: btn_media_next_track
-    name: Media next track
+    id: ${car_prefix}btn_media_next_track
+    name: "${car_name}Media next track"
     icon: mdi:skip-next
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::MEDIA_NEXT_TRACK, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::MEDIA_NEXT_TRACK, 0);
     disabled_by_default: true
 
   - platform: template
-    id: btn_media_previous_track
-    name: Media previous track
+    id: ${car_prefix}btn_media_previous_track
+    name: "${car_name}Media previous track"
     icon: mdi:skip-previous
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::MEDIA_PREVIOUS_TRACK, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::MEDIA_PREVIOUS_TRACK, 0);
     disabled_by_default: true
 
   - platform: template
-    id: btn_regenerate_key
-    name: Regenerate key
+    id: ${car_prefix}btn_regenerate_key
+    name: "${car_name}Regenerate key"
     icon: mdi:key-change
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->regenerateKey();
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->regenerateKey();
     entity_category: diagnostic
     disabled_by_default: true
 
   - platform: template
-    id: btn_force_data_update
-    name: Force data update
+    id: ${car_prefix}btn_force_data_update
+    name: "${car_name}Force data update"
     icon: mdi:database-sync
     on_press:
-      - lambda: id(tesla_ble_vehicle_id)->enqueueVCSECInformationRequest(true);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->enqueueVCSECInformationRequest(true);
     entity_category: diagnostic
 
 sensor:
   - platform: ble_client
     type: rssi
-    id: ble_signal
-    ble_client_id: ble_tesla_id
-    name: "BLE Signal"
+    id: ${car_prefix}ble_signal
+    ble_client_id: ${car_prefix}ble_tesla_id
+    name: "${car_name}BLE Signal"
     icon: mdi:bluetooth
     update_interval: 60s
     entity_category: diagnostic
 
 switch:
   - platform: template
-    id: sw_charger
-    name: "Charger"
+    id: ${car_prefix}sw_charger
+    name: "${car_name}Charger"
     optimistic: true
     icon: mdi:lightning-bolt
 #    restore_mode: RESTORE_DEFAULT_OFF
     lambda: |-
-      if ((id(charging_state).state == "Charging") or (id(charging_state).state == "Starting") or (id(charging_state).state == "Calibrating")) {
+      if ((id(${car_prefix}charging_state).state == "Charging") or (id(${car_prefix}charging_state).state == "Starting") or (id(${car_prefix}charging_state).state == "Calibrating")) {
         return true;
       } else {
         return false;
       }
     turn_on_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_SWITCH, 1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_SWITCH, 1);
     turn_off_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_SWITCH, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_SWITCH, 0);
 
   - platform: template
-    id: sw_sentry_mode
-    name: "Sentry mode"
+    id: ${car_prefix}sw_sentry_mode
+    name: "${car_name}Sentry mode"
     optimistic: true
     icon: mdi:record-circle-outline
     assumed_state: true # we can't read the state 
     restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_SENTRY_SWITCH, 1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_SENTRY_SWITCH, 1);
     turn_off_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_SENTRY_SWITCH, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_SENTRY_SWITCH, 0);
   
   - platform: template
-    id: sw_climate
-    name: "Climate"
+    id: ${car_prefix}sw_climate
+    name: "${car_name}Climate"
     optimistic: true
     icon: mdi:fan
     lambda: |-
-      if (id(is_climate_on).state) {
+      if (id(${car_prefix}is_climate_on).state) {
         return true;
       } else {
         return false;
       }
     restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_SWITCH, 1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_SWITCH, 1);
     turn_off_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_SWITCH, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_SWITCH, 0);
 
   - platform: template
-    id: sw_steering_wheel_heat
-    name: "Steering wheel heat"
+    id: ${car_prefix}sw_steering_wheel_heat
+    name: "${car_name}Steering wheel heat"
     optimistic: true
     icon: mdi:steering
     assumed_state: true # we can't read the state 
     restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_STEERING_HEATER_SWITCH, 1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_STEERING_HEATER_SWITCH, 1);
     turn_off_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_STEERING_HEATER_SWITCH, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_HVAC_STEERING_HEATER_SWITCH, 0);
   
   - platform: template
-    id: sw_defrost_car
-    name: Defrost car
+    id: ${car_prefix}sw_defrost_car
+    name: "${car_name}Defrost car"
     optimistic: true
     icon: mdi:snowflake-melt
     lambda: |-
-      if (id(defrost_state).state != "Off") {
+      if (id(${car_prefix}defrost_state).state != "Off") {
         return true;
       } else {
         return false;
       }
     turn_on_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::DEFROST_CAR, 1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::DEFROST_CAR, 1);
     turn_off_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::DEFROST_CAR, 0);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::DEFROST_CAR, 0);
 
   - platform: template
-    id: fast_poll_if_unlocked
-    name: "Fast poll if unlocked"
+    id: ${car_prefix}fast_poll_if_unlocked
+    name: "${car_name}Fast poll if unlocked"
     optimistic: true
     icon: mdi:car-door-lock-open
     entity_category: config
@@ -333,13 +335,13 @@ switch:
           condition:
             lambda: 'return x;'
           then:
-            - lambda: id(tesla_ble_vehicle_id)->fast_poll_if_unlocked_ = 1;
+            - lambda: id(${car_prefix}tesla_ble_vehicle_id)->fast_poll_if_unlocked_ = 1;
           else:
-            - lambda: id(tesla_ble_vehicle_id)->fast_poll_if_unlocked_ = 0;
+            - lambda: id(${car_prefix}tesla_ble_vehicle_id)->fast_poll_if_unlocked_ = 0;
 
   - platform: template
-    id: wake_on_boot
-    name: "Wake on boot"
+    id: ${car_prefix}wake_on_boot
+    name: "${car_name}Wake on boot"
     optimistic: true
     icon: mdi:sleep-off
     entity_category: config
@@ -350,111 +352,111 @@ switch:
           condition:
             lambda: 'return x;'
           then:
-            - lambda: id(tesla_ble_vehicle_id)->wake_on_boot_ = 1;
+            - lambda: id(${car_prefix}tesla_ble_vehicle_id)->wake_on_boot_ = 1;
           else:
-            - lambda: id(tesla_ble_vehicle_id)->wake_on_boot_ = 0;
+            - lambda: id(${car_prefix}tesla_ble_vehicle_id)->wake_on_boot_ = 0;
 
   - platform: ble_client
-    id: sw_ble_connection
-    ble_client_id: ble_tesla_id
-    name: "BLE Connection"
+    id: ${car_prefix}sw_ble_connection
+    ble_client_id: ${car_prefix}ble_tesla_id
+    name: "${car_name}BLE Connection"
     entity_category: diagnostic
 
 lock:
   - platform: template
-    id: lock_car
-    name: "Lock car"
+    id: ${car_prefix}lock_car
+    name: "${car_name}Lock car"
     optimistic: true
     icon: mdi:lock
     lambda: |-
-      if (id(is_unlocked).state) {
+      if (id(${car_prefix}is_unlocked).state) {
           return LOCK_STATE_UNLOCKED;
         } else {
           return LOCK_STATE_LOCKED;
         }
     unlock_action:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->lockVehicle(VCSEC_RKEAction_E_RKE_ACTION_UNLOCK);
+          id(${car_prefix}tesla_ble_vehicle_id)->lockVehicle(VCSEC_RKEAction_E_RKE_ACTION_UNLOCK);
     lock_action:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->lockVehicle(VCSEC_RKEAction_E_RKE_ACTION_LOCK);
+          id(${car_prefix}tesla_ble_vehicle_id)->lockVehicle(VCSEC_RKEAction_E_RKE_ACTION_LOCK);
 
 cover:
   - platform: template
-    id: cov_vent
-    name: "Vent"
+    id: ${car_prefix}cov_vent
+    name: "${car_name}Vent"
     optimistic: false #### true
     icon: mdi:car-door
     device_class: door
     lambda: |-
-      if (id(windows_state).state) {
+      if (id(${car_prefix}windows_state).state) {
         return COVER_OPEN;
       } else {
         return COVER_CLOSED;
       }
     close_action: #### This way round to make the arrows follow the desired window motion
       - lambda: |-
-          id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_WINDOWS_SWITCH, 0);
+          id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_WINDOWS_SWITCH, 0);
     open_action:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_WINDOWS_SWITCH, 1);
+          id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage (tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_WINDOWS_SWITCH, 1);
 
   - platform: template
-    id: cov_charge_port
-    name: "Charge port"
+    id: ${car_prefix}cov_charge_port
+    name: "${car_name}Charge port"
     optimistic: true
     device_class: door
     icon: mdi:ev-plug-ccs2
     lambda: |-
-      if (id(is_charge_flap_open).state) {
+      if (id(${car_prefix}is_charge_flap_open).state) {
         return COVER_OPEN;
       } else {
         return COVER_CLOSED;
       }
 #    restore_mode: RESTORE_DEFAULT_OFF
     open_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_OPEN_CHARGE_PORT_DOOR,1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_OPEN_CHARGE_PORT_DOOR,1);
     close_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CLOSE_CHARGE_PORT_DOOR,1);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CLOSE_CHARGE_PORT_DOOR,1);
   
   - platform: template
-    id: cov_boot
-    name: "Boot"
+    id: ${car_prefix}cov_boot
+    name: "${car_name}Boot"
     optimistic: true
     device_class: door
     icon: mdi:car-back
     lambda: |-
-      if (id(is_boot_open).state) {
+      if (id(${car_prefix}is_boot_open).state) {
         return COVER_OPEN;
       } else {
         return COVER_CLOSED;
       }
 #    restore_mode: RESTORE_DEFAULT_OFF
     open_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_rearTrunk_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_rearTrunk_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
     close_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_rearTrunk_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_CLOSE);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_rearTrunk_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_CLOSE);
 
   - platform: template
-    id: cov_frunk
-    name: "Frunk"
+    id: ${car_prefix}cov_frunk
+    name: "${car_name}Frunk"
     optimistic: true
     device_class: door
     icon: mdi:car
 #    assumed_state: true # we can't read the state 
     lambda: |-
-      if (id(is_frunk_open).state) {
+      if (id(${car_prefix}is_frunk_open).state) {
         return COVER_OPEN;
       } else {
         return COVER_CLOSED;
       }
     open_action:
-      - lambda: id(tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_frontTrunk_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
+      - lambda: id(${car_prefix}tesla_ble_vehicle_id)->sendVCSECClosureMoveRequestMessage (VCSEC_ClosureMoveRequest_frontTrunk_tag, VCSEC_ClosureMoveType_E_CLOSURE_MOVE_TYPE_OPEN);
     
 number:
   - platform: template
-    name: "Charging amps"
-    id: charging_amps
+    name: "${car_name}Charging amps"
+    id: ${car_prefix}charging_amps
     icon: mdi:ev-station
     unit_of_measurement: "A"
     mode: slider
@@ -465,16 +467,16 @@ number:
     set_action:
       - lambda: |-
           int var_x = static_cast<int>(x);
-          id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_AMPS, var_x);
+          id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_AMPS, var_x);
     lambda: |-
-      if (id(max_amps).has_state())
+      if (id(${car_prefix}max_amps).has_state())
       {
-        return id(max_amps).state;
+        return id(${car_prefix}max_amps).state;
       }
       else return (0);
   - platform: template
-    name: "Charging limit"
-    id: charging_limit
+    name: "${car_name}Charging limit"
+    id: ${car_prefix}charging_limit
     icon: mdi:ev-station
     unit_of_measurement: "%"
     mode: slider
@@ -485,16 +487,16 @@ number:
     set_action:
       - lambda: |-
           int var_x = static_cast<int>(x);
-          id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_LIMIT, var_x);
+          id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CHARGING_LIMIT, var_x);
     lambda: |-
-      if (id(max_soc).has_state())
+      if (id(${car_prefix}max_soc).has_state())
       {
-        return id(max_soc).state;
+        return id(${car_prefix}max_soc).state;
       }
       else return (0);
   - platform: template
-    name: "Climate temperature"
-    id: set_climate_temp
+    name: "${car_name}Climate temperature"
+    id: ${car_prefix}set_climate_temp
     icon: mdi:thermometer-lines
     unit_of_measurement: "°C"
     mode: slider
@@ -505,18 +507,18 @@ number:
     set_action:
       - lambda: |-
           int var_x = static_cast<int>(x);
-          id(tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CLIMATE_TEMP, var_x);
+          id(${car_prefix}tesla_ble_vehicle_id)->sendCarServerVehicleActionMessage(tesla_ble_vehicle::BLE_CarServer_VehicleAction::SET_CLIMATE_TEMP, var_x);
     lambda: |-
-      if (id(driver_temp).has_state())
+      if (id(${car_prefix}driver_temp).has_state())
       {
-        return id(driver_temp).state;
+        return id(${car_prefix}driver_temp).state;
       }
       else return (0);
     disabled_by_default: true
 
   - platform: template
-    id: post_wake_poll_time
-    name: "Post wake poll time"
+    id: ${car_prefix}post_wake_poll_time
+    name: "${car_name}Post wake poll time"
     icon: mdi:timelapse
     min_value: 0
     max_value: 1000
@@ -529,10 +531,10 @@ number:
     entity_category: config
     on_value:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->post_wake_poll_time_ = x * 1000;
+          id(${car_prefix}tesla_ble_vehicle_id)->post_wake_poll_time_ = x * 1000;
   - platform: template
-    id: poll_data_period
-    name: "Poll data period"
+    id: ${car_prefix}poll_data_period
+    name: "${car_name}Poll data period"
     icon: mdi:timer-outline
     min_value: 0
     max_value: 1000
@@ -545,10 +547,10 @@ number:
     entity_category: config
     on_value:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->poll_data_period_ = x * 1000;
+          id(${car_prefix}tesla_ble_vehicle_id)->poll_data_period_ = x * 1000;
   - platform: template
-    id: poll_asleep_period
-    name: "Poll asleep period"
+    id: ${car_prefix}poll_asleep_period
+    name: "${car_name}Poll asleep period"
     icon: mdi:bed-clock
     min_value: 0
     max_value: 1000
@@ -561,10 +563,10 @@ number:
     entity_category: config
     on_value:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->poll_asleep_period_ = x * 1000;
+          id(${car_prefix}tesla_ble_vehicle_id)->poll_asleep_period_ = x * 1000;
   - platform: template
-    id: poll_charging_period
-    name: "Poll charging period"
+    id: ${car_prefix}poll_charging_period
+    name: "${car_name}Poll charging period"
     icon: mdi:timer-sync-outline
     min_value: 0
     max_value: 1000
@@ -577,10 +579,10 @@ number:
     entity_category: config
     on_value:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->poll_charging_period_ = x * 1000;
+          id(${car_prefix}tesla_ble_vehicle_id)->poll_charging_period_ = x * 1000;
   - platform: template
-    id: ble_disconnected_min_time
-    name: "BLE disconnected min time"
+    id: ${car_prefix}ble_disconnected_min_time
+    name: "${car_name}BLE disconnected min time"
     icon: mdi:bluetooth-connect
     min_value: 0
     max_value: 1000
@@ -593,4 +595,4 @@ number:
     entity_category: config
     on_value:
       - lambda: |-
-          id(tesla_ble_vehicle_id)->ble_disconnected_min_time_ = x * 1000;
+          id(${car_prefix}tesla_ble_vehicle_id)->ble_disconnected_min_time_ = x * 1000;

--- a/packages/common.yml
+++ b/packages/common.yml
@@ -15,13 +15,6 @@ binary_sensor:
   - platform: status
     id: esphome_tesla_ble_status
     name: "Status"
-  - platform: ble_presence
-    id: esphome_tesla_ble_ble_status
-    mac_address: $ble_mac_address
-    device_class: connectivity
-    name: "BLE Status"
-    entity_category: diagnostic
-    timeout: $ble_presence_timeout
 
 text_sensor:
   - platform: version

--- a/packages/language_de.yml
+++ b/packages/language_de.yml
@@ -2,136 +2,139 @@
 # - localize all names to German terminology
 # - use km. instead of mi for distance units by default
 
+substitutions:
+  car_prefix: ""
+  car_name: ""
 
 tesla_ble_vehicle:
-  is_asleep:
-    name: "Im Ruhezustand"
-  is_user_present:
-    name: "Person erkannt"
-  is_unlocked:
-    name: "Entriegelt"
-  is_charge_flap_open:
-    icon: mdi:ev-plug-ccs2
-    name: "Ladeanschluss"
-  is_boot_open:
-    name: "Kofferraum hinten"
-  is_frunk_open:
-    name: "Kofferraum vorne"
-  shift_state:
-    name: "Schaltstellung"
-  defrost_state:
-    name: "Enteisung"
-  charge_state:
-    name: "Ladezustand"
-  odometer:
-    name: "Kilometerstand"
-    filters:
-      - multiply: 1.609344
-    unit_of_measurement: km
-  charge_current:
-    name: "Ladestrom"
-  charge_voltage:
-    name: "Ladespannung"
-  charge_power:
-    name: "Ladeleistung"
-  charge_energy_added:
-    name: "Bezogene Energie"
-  charge_distance_added:
-    name: "Reichweitenzuwachs"
-    filters:
-      - multiply: 1.609344
-    unit_of_measurement: km
-  max_soc:
-    name: "Ladelimit"
-  max_amps:
-    name: "Strombegrenzung"
-  mins_to_limit:
-    name: "Zeit bis Ladeende"
-  battery_range:
-    name: "Reichweite"
-    filters:
-      - multiply: 1.609344
-    unit_of_measurement: km
-  charging_state:
-    name: "Ladezustand"
-  last_update:
-    name: "Zuletzt aktualisiert"
-  is_climate_on:
-    name: "Klimaanlage"
-  internal_temp:
-    name: "Innenraumtemperatur"
-  external_temp:
-    name: "Außentemperatur"
-  windows_state:
-    name: "Fenster"
-  tpms_pressure_fl:
-    name: "Reifendruck vorne links"
-  tpms_pressure_fr:
-    name: "Reifendruck vorne rechts"
-  tpms_pressure_rl:
-    name: "Reifendruck hinten links"
-  tpms_pressure_rr:
-    name: "Reifendruck hinten rechts"
+  - id: !extend ${car_prefix}tesla_ble_vehicle_id
+    is_asleep:
+      name: "${car_name}Im Ruhezustand"
+    is_user_present:
+      name: "${car_name}Person erkannt"
+    is_unlocked:
+      name: "${car_name}Entriegelt"
+    is_charge_flap_open:
+      icon: mdi:ev-plug-ccs2
+      name: "${car_name}Ladeanschluss"
+    is_boot_open:
+      name: "${car_name}Kofferraum hinten"
+    is_frunk_open:
+      name: "${car_name}Kofferraum vorne"
+    shift_state:
+      name: "${car_name}Schaltstellung"
+    defrost_state:
+      name: "${car_name}Enteisung"
+    charge_state:
+      name: "${car_name}Ladezustand"
+    odometer:
+      name: "${car_name}Kilometerstand"
+      filters:
+        - multiply: 1.609344
+      unit_of_measurement: km
+    charge_current:
+      name: "${car_name}Ladestrom"
+    charge_voltage:
+      name: "${car_name}Ladespannung"
+    charge_power:
+      name: "${car_name}Ladeleistung"
+    charge_energy_added:
+      name: "${car_name}Bezogene Energie"
+    charge_distance_added:
+      name: "${car_name}Reichweitenzuwachs"
+      filters:
+        - multiply: 1.609344
+      unit_of_measurement: km
+    max_soc:
+      name: "${car_name}Ladelimit"
+    max_amps:
+      name: "${car_name}Strombegrenzung"
+    mins_to_limit:
+      name: "${car_name}Zeit bis Ladeende"
+    battery_range:
+      name: "${car_name}Reichweite"
+      filters:
+        - multiply: 1.609344
+      unit_of_measurement: km
+    charging_state:
+      name: "${car_name}Ladezustand"
+    last_update:
+      name: "${car_name}Zuletzt aktualisiert"
+    is_climate_on:
+      name: "${car_name}Klimaanlage"
+    internal_temp:
+      name: "${car_name}Innenraumtemperatur"
+    external_temp:
+      name: "${car_name}Außentemperatur"
+    windows_state:
+      name: "${car_name}Fenster"
+    tpms_pressure_fl:
+      name: "${car_name}Reifendruck vorne links"
+    tpms_pressure_fr:
+      name: "${car_name}Reifendruck vorne rechts"
+    tpms_pressure_rl:
+      name: "${car_name}Reifendruck hinten links"
+    tpms_pressure_rr:
+      name: "${car_name}Reifendruck hinten rechts"
 button:
-  - id: !extend ble_pair
-    name: "BLE-Schlüsselpaarung"
-  - id: !extend btn_wake_up
-    name: "Aufwecken"
-  - id: !extend btn_flash_light
-    name: "Lichthupe"
-  - id: !extend btn_sound_horn
-    name: "Hupen"
-  - id: !extend btn_unlock_charge_port
-    name: "Ladeanschluss entriegeln"
-  - id: !extend btn_unlatch_driver_door
-    name: "Fahrertür öffnen"
-  - id: !extend btn_regenerate_key
-    name: "Schlüssel neu generieren"
-  - id: !extend btn_force_data_update
-    name: "Manuelle Datenaktualisierung"
+  - id: !extend ${car_prefix}ble_pair
+    name: "${car_name}BLE-Schlüsselpaarung"
+  - id: !extend ${car_prefix}btn_wake_up
+    name: "${car_name}Aufwecken"
+  - id: !extend ${car_prefix}btn_flash_light
+    name: "${car_name}Lichthupe"
+  - id: !extend ${car_prefix}btn_sound_horn
+    name: "${car_name}Hupen"
+  - id: !extend ${car_prefix}btn_unlock_charge_port
+    name: "${car_name}Ladeanschluss entriegeln"
+  - id: !extend ${car_prefix}btn_unlatch_driver_door
+    name: "${car_name}Fahrertür öffnen"
+  - id: !extend ${car_prefix}btn_regenerate_key
+    name: "${car_name}Schlüssel neu generieren"
+  - id: !extend ${car_prefix}btn_force_data_update
+    name: "${car_name}Manuelle Datenaktualisierung"
 sensor:
-  - id: !extend ble_signal
-    name: "BLE-Signalstärke"
+  - id: !extend ${car_prefix}ble_signal
+    name: "${car_name}BLE-Signalstärke"
 switch:
-  - id: !extend sw_charger
-    name: "Laden"
-  - id: !extend sw_sentry_mode
-    name: "Wächtermodus"
-  - id: !extend sw_climate
-    name: "Klimaanlage"
-  - id: !extend sw_steering_wheel_heat
-    name: "Lenkradheizung"
-  - id: !extend sw_defrost_car
-    name: "Enteisung"
-  - id: !extend sw_ble_connection
-    name: "BLE-Verbindung"
-  - id: !extend fast_poll_if_unlocked
-    name: "Schnelle Abfrage bei entriegelt"
+  - id: !extend ${car_prefix}sw_charger
+    name: "${car_name}Laden"
+  - id: !extend ${car_prefix}sw_sentry_mode
+    name: "${car_name}Wächtermodus"
+  - id: !extend ${car_prefix}sw_climate
+    name: "${car_name}Klimaanlage"
+  - id: !extend ${car_prefix}sw_steering_wheel_heat
+    name: "${car_name}Lenkradheizung"
+  - id: !extend ${car_prefix}sw_defrost_car
+    name: "${car_name}Enteisung"
+  - id: !extend ${car_prefix}sw_ble_connection
+    name: "${car_name}BLE-Verbindung"
+  - id: !extend ${car_prefix}fast_poll_if_unlocked
+    name: "${car_name}Schnelle Abfrage bei entriegelt"
 lock:
-  - id: !extend lock_car
-    name: "Auto verriegeln"
+  - id: !extend ${car_prefix}lock_car
+    name: "${car_name}Auto verriegeln"
 cover:
-  - id: !extend cov_vent
-    name: "Belüftung"
-  - id: !extend cov_charge_port
-    name: "Ladeanschluss"
-  - id: !extend cov_boot
-    name: "Kofferraum hinten"
-  - id: !extend cov_frunk
-    name: "Kofferraum vorne"
+  - id: !extend ${car_prefix}cov_vent
+    name: "${car_name}Belüftung"
+  - id: !extend ${car_prefix}cov_charge_port
+    name: "${car_name}Ladeanschluss"
+  - id: !extend ${car_prefix}cov_boot
+    name: "${car_name}Kofferraum hinten"
+  - id: !extend ${car_prefix}cov_frunk
+    name: "${car_name}Kofferraum vorne"
 number:
-  - id: !extend charging_amps
-    name: "Ladestrom"
-  - id: !extend charging_limit
-    name: "Ladelimit"
-  - id: !extend post_wake_poll_time
-    name: "Abfrageintervall nach Aufwecken"
-  - id: !extend poll_data_period
-    name: "Standard-Abfrageintervall"
-  - id: !extend poll_asleep_period
-    name: "Abfrageintervall im Ruhezustand"
-  - id: !extend poll_charging_period
-    name: "Abfrageintervall beim Laden"
-  - id: !extend ble_disconnected_min_time
-
-    name: "Min. Zeit für BLE-Trennung"
+  - id: !extend ${car_prefix}charging_amps
+    name: "${car_name}Ladestrom"
+  - id: !extend ${car_prefix}charging_limit
+    name: "${car_name}Ladelimit"
+  - id: !extend ${car_prefix}post_wake_poll_time
+    name: "${car_name}Abfrageintervall nach Aufwecken"
+  - id: !extend ${car_prefix}poll_data_period
+    name: "${car_name}Standard-Abfrageintervall"
+  - id: !extend ${car_prefix}poll_asleep_period
+    name: "${car_name}Abfrageintervall im Ruhezustand"
+  - id: !extend ${car_prefix}poll_charging_period
+    name: "${car_name}Abfrageintervall beim Laden"
+  - id: !extend ${car_prefix}ble_disconnected_min_time
+    name: "${car_name}Min. Zeit für BLE-Trennung"

--- a/packages/language_hu.yml
+++ b/packages/language_hu.yml
@@ -2,163 +2,165 @@
 # - localize all names to Hungarian terminology
 # - use km. instead of mi for distance units by default
 
+substitutions:
+  car_prefix: ""
+  car_name: ""
+
 tesla_ble_vehicle:
-  is_asleep:
-    id: is_asleep
-    name: "Alvó állapotban"
-  is_user_present:
-    name: "Személy észlelve"
-  is_unlocked:
-    name: "Nyitva van"
-  is_charge_flap_open:
-    icon: mdi:ev-plug-ccs2
-    name: "Töltőnyílás"
-  is_boot_open:
-    name: "Csomagtartó hátsó"
-  is_frunk_open:
-    name: "Csomagtartó első"
-  shift_state:
-    name: "Váltó pozíció"
-  defrost_state:
-    name: "Fagymentesítés"
-  charge_state:
-    name: "Töltöttségi szint"
-  odometer:
-    id: odometer
-    name: "Km. óra állás"
-    filters:
-      - multiply: 1.609344 # in hundredths of a mile but, multiply by 0.01 alredy in package file
-    unit_of_measurement: km
-  charge_current:
-    name: "Töltési áram"
-  charge_voltage:
-    name: "Töltési feszültség"  
-  charge_power:
-    name: "Töltési teljesítmény"
-  charge_energy_added:
-    name: "Vételezett energia"
-  charge_distance_added:
-    name: "Hatótáv növekedés"
-    filters:
-      - multiply: 1.609344 # miles
-    unit_of_measurement: km
-  max_soc:
-    name: "Töltési limit"
-  max_amps:
-    name: "Töltési áram limit"
-  mins_to_limit:
-    name: "Idő a töltés befejezéséig"
-  battery_range:
-    id: battery_range
-    name: "Hatótáv"
-    filters:
-      - multiply: 1.609344 # miles
-    unit_of_measurement: km
-  charging_state:
-    name: "Töltési állapot"
-  charge_port_latch_state:
-    name: "Töltőnyílás retesz"
-  last_update:
-    name: "Utoljára frissült"
-  is_climate_on:
-    name: "Klíma"
-  internal_temp:
-    name: "Hőmérséklet bent"
-  external_temp:
-    name: "Hőmérséklet kint"
-  windows_state:
-    name: "Ablakok"
-  tpms_pressure_fl:
-    name: "Guminyomás bal első"
-  tpms_pressure_fr:
-    name: "Guminyomás jobb első"
-  tpms_pressure_rl:
-    name: "Guminyomás bal hátsó"
-  tpms_pressure_rr:
-    name: "Guminyomás jobb hátsó"
-  ble_disconnected_time:
-    name: "BLE lecsatlakozva"
-  charger_phases:
-    name: "Töltő fázisok"
-  charge_rate:
-    name: "Töltési sebesség"
-  driver_temp:
-    name: "Klíma hőmérséklet"
+  - id: !extend ${car_prefix}tesla_ble_vehicle_id
+    is_asleep:
+      name: "${car_name}Alvó állapotban"
+    is_user_present:
+      name: "${car_name}Személy észlelve"
+    is_unlocked:
+      name: "${car_name}Nyitva van"
+    is_charge_flap_open:
+      icon: mdi:ev-plug-ccs2
+      name: "${car_name}Töltőnyílás"
+    is_boot_open:
+      name: "${car_name}Csomagtartó hátsó"
+    is_frunk_open:
+      name: "${car_name}Csomagtartó első"
+    shift_state:
+      name: "${car_name}Váltó pozíció"
+    defrost_state:
+      name: "${car_name}Fagymentesítés"
+    charge_state:
+      name: "${car_name}Töltöttségi szint"
+    odometer:
+      name: "${car_name}Km. óra állás"
+      filters:
+        - multiply: 1.609344 # in hundredths of a mile but, multiply by 0.01 alredy in package file
+      unit_of_measurement: km
+    charge_current:
+      name: "${car_name}Töltési áram"
+    charge_voltage:
+      name: "${car_name}Töltési feszültség"
+    charge_power:
+      name: "${car_name}Töltési teljesítmény"
+    charge_energy_added:
+      name: "${car_name}Vételezett energia"
+    charge_distance_added:
+      name: "${car_name}Hatótáv növekedés"
+      filters:
+        - multiply: 1.609344 # miles
+      unit_of_measurement: km
+    max_soc:
+      name: "${car_name}Töltési limit"
+    max_amps:
+      name: "${car_name}Töltési áram limit"
+    mins_to_limit:
+      name: "${car_name}Idő a töltés befejezéséig"
+    battery_range:
+      name: "${car_name}Hatótáv"
+      filters:
+        - multiply: 1.609344 # miles
+      unit_of_measurement: km
+    charging_state:
+      name: "${car_name}Töltési állapot"
+    charge_port_latch_state:
+      name: "${car_name}Töltőnyílás retesz"
+    last_update:
+      name: "${car_name}Utoljára frissült"
+    is_climate_on:
+      name: "${car_name}Klíma"
+    internal_temp:
+      name: "${car_name}Hőmérséklet bent"
+    external_temp:
+      name: "${car_name}Hőmérséklet kint"
+    windows_state:
+      name: "${car_name}Ablakok"
+    tpms_pressure_fl:
+      name: "${car_name}Guminyomás bal első"
+    tpms_pressure_fr:
+      name: "${car_name}Guminyomás jobb első"
+    tpms_pressure_rl:
+      name: "${car_name}Guminyomás bal hátsó"
+    tpms_pressure_rr:
+      name: "${car_name}Guminyomás jobb hátsó"
+    ble_disconnected_time:
+      name: "${car_name}BLE lecsatlakozva"
+    charger_phases:
+      name: "${car_name}Töltő fázisok"
+    charge_rate:
+      name: "${car_name}Töltési sebesség"
+    driver_temp:
+      name: "${car_name}Klíma hőmérséklet"
 
 button:
-  - id: !extend ble_pair
-    name: "BLE kulcspárosítás"
-  - id: !extend btn_wake_up
-    name: "Felébresztés"
-  - id: !extend btn_flash_light
-    name: "Fénykürt"
-  - id: !extend btn_sound_horn
-    name: "Dudaszó"
-  - id: !extend btn_unlock_charge_port
-    name: "Töltőnyílás feloldása"
-  - id: !extend btn_unlatch_driver_door
-    name: "Vezetőajtó kinyitás"
-  - id: !extend btn_regenerate_key
-    name: "Kulcs újragenerálása"
-  - id: !extend btn_force_data_update
-    name: "Kézi adatfrissítés"
-  - id: !extend btn_media_play
-    name: "Média lejátszás⁄folytatás"
-  - id: !extend btn_media_next_track
-    name: "Média következő"
-  - id: !extend btn_media_previous_track
-    name: "Média előző"
+  - id: !extend ${car_prefix}ble_pair
+    name: "${car_name}BLE kulcspárosítás"
+  - id: !extend ${car_prefix}btn_wake_up
+    name: "${car_name}Felébresztés"
+  - id: !extend ${car_prefix}btn_flash_light
+    name: "${car_name}Fénykürt"
+  - id: !extend ${car_prefix}btn_sound_horn
+    name: "${car_name}Dudaszó"
+  - id: !extend ${car_prefix}btn_unlock_charge_port
+    name: "${car_name}Töltőnyílás feloldása"
+  - id: !extend ${car_prefix}btn_unlatch_driver_door
+    name: "${car_name}Vezetőajtó kinyitás"
+  - id: !extend ${car_prefix}btn_regenerate_key
+    name: "${car_name}Kulcs újragenerálása"
+  - id: !extend ${car_prefix}btn_force_data_update
+    name: "${car_name}Kézi adatfrissítés"
+  - id: !extend ${car_prefix}btn_media_play
+    name: "${car_name}Média lejátszás⁄folytatás"
+  - id: !extend ${car_prefix}btn_media_next_track
+    name: "${car_name}Média következő"
+  - id: !extend ${car_prefix}btn_media_previous_track
+    name: "${car_name}Média előző"
 
 sensor:
-  - id: !extend ble_signal
-    name: "BLE jelszint"
+  - id: !extend ${car_prefix}ble_signal
+    name: "${car_name}BLE jelszint"
 
 switch:
-  - id: !extend sw_charger
-    name: "Töltés"
-  - id: !extend sw_sentry_mode
-    name: "Őrszem"
-  - id: !extend sw_climate
-    name: "Klíma"
-  - id: !extend sw_steering_wheel_heat
-    name: "Kormányfűtés"
-  - id: !extend sw_defrost_car
-    name: "Fagymentesítés"
-  - id: !extend sw_ble_connection
-    name: "BLE kapcsolat"
-  - id: !extend fast_poll_if_unlocked
-    name: "Lekérdezés gyors nyitott zárnál"
-  - id: !extend wake_on_boot
-    name: "Felébresztés ESPHome bootoláskor"
+  - id: !extend ${car_prefix}sw_charger
+    name: "${car_name}Töltés"
+  - id: !extend ${car_prefix}sw_sentry_mode
+    name: "${car_name}Őrszem"
+  - id: !extend ${car_prefix}sw_climate
+    name: "${car_name}Klíma"
+  - id: !extend ${car_prefix}sw_steering_wheel_heat
+    name: "${car_name}Kormányfűtés"
+  - id: !extend ${car_prefix}sw_defrost_car
+    name: "${car_name}Fagymentesítés"
+  - id: !extend ${car_prefix}sw_ble_connection
+    name: "${car_name}BLE kapcsolat"
+  - id: !extend ${car_prefix}fast_poll_if_unlocked
+    name: "${car_name}Lekérdezés gyors nyitott zárnál"
+  - id: !extend ${car_prefix}wake_on_boot
+    name: "${car_name}Felébresztés ESPHome bootoláskor"
 
 lock:
-  - id: !extend lock_car
-    name: "Autó zár"
+  - id: !extend ${car_prefix}lock_car
+    name: "${car_name}Autó zár"
 
 cover:
-  - id: !extend cov_vent
-    name: "Szellőztetés"
-  - id: !extend cov_charge_port
-    name: "Töltőnyílás"
-  - id: !extend cov_boot
-    name: "Csomagtartó hátsó"
-  - id: !extend cov_frunk
-    name: "Csomagtartó első"
-    
+  - id: !extend ${car_prefix}cov_vent
+    name: "${car_name}Szellőztetés"
+  - id: !extend ${car_prefix}cov_charge_port
+    name: "${car_name}Töltőnyílás"
+  - id: !extend ${car_prefix}cov_boot
+    name: "${car_name}Csomagtartó hátsó"
+  - id: !extend ${car_prefix}cov_frunk
+    name: "${car_name}Csomagtartó első"
+
 number:
-  - id: !extend charging_amps
-    name: "Töltési áram"
-  - id: !extend charging_limit
-    name: "Töltési limit"
-  - id: !extend set_climate_temp
-    name: "Klíma hőmérséklet"
-  - id: !extend post_wake_poll_time
-    name: "Lekérdezés gyak. felébresztés után"
-  - id: !extend poll_data_period
-    name: "Lekérdezés gyak. alapértelmezett"
-  - id: !extend poll_asleep_period
-    name: "Lekérdezés gyak. alvó állapotban"
-  - id: !extend poll_charging_period
-    name: "Lekérdezés gyak. töltés közben"
-  - id: !extend ble_disconnected_min_time
-    name: "BLE lecsatlakozott állapot min idő"
+  - id: !extend ${car_prefix}charging_amps
+    name: "${car_name}Töltési áram"
+  - id: !extend ${car_prefix}charging_limit
+    name: "${car_name}Töltési limit"
+  - id: !extend ${car_prefix}set_climate_temp
+    name: "${car_name}Klíma hőmérséklet"
+  - id: !extend ${car_prefix}post_wake_poll_time
+    name: "${car_name}Lekérdezés gyak. felébresztés után"
+  - id: !extend ${car_prefix}poll_data_period
+    name: "${car_name}Lekérdezés gyak. alapértelmezett"
+  - id: !extend ${car_prefix}poll_asleep_period
+    name: "${car_name}Lekérdezés gyak. alvó állapotban"
+  - id: !extend ${car_prefix}poll_charging_period
+    name: "${car_name}Lekérdezés gyak. töltés közben"
+  - id: !extend ${car_prefix}ble_disconnected_min_time
+    name: "${car_name}BLE lecsatlakozott állapot min idő"

--- a/tesla-ble-dual.example.yml
+++ b/tesla-ble-dual.example.yml
@@ -1,0 +1,85 @@
+substitutions:
+  # Note substitutions in your yaml will override those here
+  friendly_name: Tesla BLE Dual
+  device_name: tesla-ble-dual
+  device_description: Tesla BLE Dual Car Setup
+
+# The following shows the default board and variant settings.
+# Uncomment and changing them is only needed if they are not appropriate for your board (see read.me documentation for support):
+  #board: "esp32dev"
+  #variant: "ESP32"
+
+api:
+  encryption:
+    key: xxxxxxxxxxxxx= # use "key: !secret your_secret_key_name" for greater security
+
+# Uncomment if you want to use ethernet instead
+# See https://esphome.io/components/ethernet/ for actual configuration you will need
+# ethernet:
+#   type: LAN8720
+#   ...
+# wifi: !remove
+# sensor:
+#   - id: !remove esphome_tesla_ble_wifi_signal
+# text_sensor:
+#   - id: !remove esphome_wifi_ip_address
+# esp32_ble_tracker:
+#   scan_parameters:
+#     continuous: true
+
+packages:
+  base_packages:
+    url: https://github.com/PedroKTFC/esphome-tesla-ble/
+    files:
+      - packages/base.yml
+      - packages/common.yml
+      - packages/project.yml
+  #    - packages/listener.yml  # Uncomment this to scan find your VIN BLE MAC address
+
+  car1:
+    url: https://github.com/PedroKTFC/esphome-tesla-ble/
+    files:
+      - path: packages/client.yml
+        vars:
+          ble_mac_address: !secret car1_ble_mac_address
+          tesla_vin: !secret car1_tesla_vin
+          car_prefix: "car1_"
+          car_name: "Car 1 "
+  #    - path: packages/language_hu.yml # Uncomment this to translate the entity names to your language. If yours is missing, submit a PR here!
+  #      vars:
+  #        car_prefix: "car1_"
+  #        car_name: "Car 1 "
+
+  car2:
+    url: https://github.com/PedroKTFC/esphome-tesla-ble/
+    files:
+      - path: packages/client.yml
+        vars:
+          ble_mac_address: !secret car2_ble_mac_address
+          tesla_vin: !secret car2_tesla_vin
+          car_prefix: "car2_"
+          car_name: "Car 2 "
+  #    - path: packages/language_de.yml # Uncomment this to translate the entity names to your language. If yours is missing, submit a PR here!
+  #      vars:
+  #        car_prefix: "car2_"
+  #        car_name: "Car 2 "
+
+# The following shows how to change the name of a sensor and how to change any of the parameters.
+# Use the car's id prefix (car1_ or car2_) to target a specific car:
+# tesla_ble_vehicle: # THIS LINE MUST BE UNCOMMENTED IF ANY OF THE CHANGES BELOW ARE WANTED
+
+# You can change any sensor name in Home Assistant. However you can also change them here if it is more convenient for you.
+# For a list of all sensors etc, see the file client.yml in the packages directory.
+#  - id: car1_tesla_ble_vehicle_id
+#    odometer: # miles by default, edit the entity in home assistant if you need km
+#      name: "Car 1 Odometro" # Rename if desired
+# End of renaming
+
+# At the time of writing, these are set to the default values. If you require a different value, uncomment and edit the value
+#    update_interval: 10s # Base polling interval, used for VCSEC sensors
+#    post_wake_poll_time: 300 # How long to poll for data after car awakes at poll_data_period speed (s)
+#    poll_data_period: 60 # Polling interval after awakening during post_wake_poll_time interval (s)
+#    poll_charging_period: 10 # Period to poll for data when charging (s)
+#    poll_asleep_period: 60 # Period to poll for data when asleep (s)
+#    ble_disconnected_min_time: 300 # Minimum time BLE must be disconnected before sensors are Unknown (s)
+#    fast_poll_if_unlocked: 1 # if != 0, fast polls are enabled when unlocked


### PR DESCRIPTION
Thanks a lot for your work, I've been using this project for some time!

Recently I bought a second Tesla and wanted to connect to it without using a second board, power adapter, etc.
I used AI to make the initial changes and I have it running on my ESP32 for about one month without issues.

Now I found the time to review and improve the initial code changes, to fix the language files and run all necessary test. Please find below a full description of my changes and tests.

### Feature
Allows a single ESP32 device to manage two (or more) Tesla vehicles simultaneously over BLE. Useful for households with multiple Teslas sharing a home network, avoiding the need for a dedicated ESP32 per car.

Each car is configured independently via car_prefix and car_name substitutions, which namespace all component IDs and Home Assistant entity names. The single-car setup is fully backward-compatible — no changes needed for existing users.

### Code Changes
#### Component (components/tesla_ble_vehicle/)

- `__init__.py`: Added `MULTI_CONF = True` to allow multiple instances. NVS namespace is now derived from the component ID — defaults to `"storage"` for the original ID (backward compat), otherwise uses the first 15 characters of the ID.
- `tesla_ble_vehicle.h/.cpp`: Added `nvs_namespace_` field and `set_nvs_namespace()` to support configurable NVS namespaces per instance.

#### Packages

- `client.yml`: Converted `tesla_ble_vehicle` to list format; added `car_prefix` / `car_name` substitutions for namespacing IDs and entity names. BLE presence sensor moved here from `common.yml` (it's car-specific).
- `common.yml`: BLE presence sensor removed.
- `language_de.yml`, `language_hu.yml`: Extended `tesla_ble_vehicle` and all other entities based on `${car_prefix}` and prepended `${car_name}` to translations.

#### Example

- `tesla-ble-dual.example.yml`: New example demonstrating the dual-car remote-package setup using the ESPHome path: + vars: per-file syntax.

### Tests executed successfully

#### Single car, using `tesla-ble.example.yml`:

- [x] Update to current code from previous versions does not break pairing or connectivity
- [x] Changing `car_prefix` from the default `""` breaks pairing as expected
- [x] Reverting `car_prefix` to the default `""` restores pairing
- [x] Applying language file with `car_prefix: ""` correctly translates names
- [x] Applying language file with non-default `car_prefix` correctly translates names
- [x] Changing `car_name` updates entity names for both original and translated options

#### Dual car, using `tesla-ble-dual.example.yml`:
- [x] Using different `car_prefix` and `car_name` correctly creates two sets of entities
- [x] Keeping the default `car_prefix` for one of the cars preserves pairing for that car
- [x] Pairing and connectivity works for each car independently
- [x] Using language file with either car translates names for that car
- [x] Can use different language files for each car
