### PR TITLE
Update listener.yml: Remove redundant substitution

### DIFF
--- a/packages/listener.yml
+++ b/packages/listener.yml
@@ -1,6 +1,3 @@
-substitutions:
-  tesla_vin: !secret tesla_vin
-
 # Enable this to scan for BLE devices
 tesla_ble_listener:
   vin: $tesla_vin


### PR DESCRIPTION
the substitution of tesla_vin from the secrets file is redundant with the standard config. This can cause issues when the user configures the VIN in the project yaml, or when there are multiple vehicles.