### PR TITLE
Update language_de.yml

### DIFF
--- a/packages/language_de.yml
+++ b/packages/language_de.yml
@@ -20,11 +20,6 @@ tesla_ble_vehicle:
     name: "Fahrstufe"
   defrost_state:
     name: "Enteisung"
-    filters:
-      - substitute:
-          - "Off -> Aus"
-          - "Normal -> Normal"
-          - "Max -> Maximal"
   charge_state:
     name: "Ladezustand"
   odometer:
@@ -58,15 +53,6 @@ tesla_ble_vehicle:
     unit_of_measurement: km
   charging_state:
     name: "Ladezustand"
-    filters:
-      - substitute:
-          - "Disconnected -> Getrennt"
-          - "Engaged -> Angeschlossen"
-          - "Charging -> Lädt"
-          - "Starting -> Startet"
-          - "Complete -> Fertig"
-          - "Stopped -> Gestoppt"
-          - "NoPower -> Kein Strom"
   charge_port_latch_state:
     name: "Verriegelung Ladeanschluss"
     filters:


### PR DESCRIPTION
Completely remove substitute filter for defrost_state and charging_state 
By the way, I kept the charge_port_latch_state filter since it doesn't break anything. We can just toss the other ones back in as soon as the core architecture is ready for it :)

I also just tested this updated version on my end, and I couldn't find any more errors

BUG:#343